### PR TITLE
Update listen.js for add smokesensor

### DIFF
--- a/lib/listen.js
+++ b/lib/listen.js
@@ -215,4 +215,50 @@ module.exports = function listen(){
             })
             .catch(console.log); 
     });
+    
+     hub.on('data.smoke', function (sid, voltage, density, alarm) {
+console.info('smokedetector', sid, voltage, density, alarm);
+
+var newDevice = {
+    device: {
+        name: 'Smoke detector',
+        identifier: sid,
+        protocol: 'zigbee',
+        service: 'xiaomi-home'
+    },
+    types: [
+        {
+            identifier: 'alarm',
+            type: 'binary',
+            sensor: true,
+            min: 0,
+            max: 1
+        },
+	{
+            identifier: 'density',
+            type: 'density',
+            sensor: true,
+            unit: '%',
+            min: 0,
+            max: 100
+        },
+	{
+            identifier: 'voltage',
+            type: 'voltage',
+            sensor: true,
+            min: 0,
+            max: 1000
+        }
+    ]
+};
+
+createDevice(newDevice)
+    .then((result) => {
+        return Promise.all([
+            createDeviceState(result.types[0].id, alarm),
+            createDeviceState(result.types[1].id, density)
+        ]);
+    })
+.catch(console.log);  
+});
 };


### PR DESCRIPTION
Add smoke detector

Work now with my node-xiaomi-smart-home fork (https://github.com/Retlawdcp/node-xiaomi-smart-home) or wait quibusus update (when?), as you want 

lines to add in code : 

hub.on('data.smoke', function (sid, voltage, density, alarm) {
console.info('smokedetector', sid, voltage, density, alarm);

var newDevice = {
    device: {
        name: 'Smoke detector',
        identifier: sid,
        protocol: 'zigbee',
        service: 'xiaomi-home'
    },
    types: [
        {
            identifier: 'alarm',
            type: 'binary',
            sensor: true,
            min: 0,
            max: 1
        },
	{
            identifier: 'density',
            type: 'density',
            sensor: true,
            unit: '%',
            min: 0,
            max: 100
        },
	{
            identifier: 'voltage',
            type: 'voltage',
            sensor: true,
            min: 0,
            max: 1000
        }
    ]
};

createDevice(newDevice)
    .then((result) => {
        return Promise.all([
            createDeviceState(result.types[0].id, alarm),
            createDeviceState(result.types[1].id, density)
        ]);
    })
.catch(console.log);  
});